### PR TITLE
Ignore test connectivity file from test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test: .installed .venv_init
 	${VENV_DIRECTORY}/${EXEC_DIR}/${PYTHON_EXE} -m pytest ${TEST_DIRECTORY}/ --suppress-no-test-exit-code
 
 cover: .installed .venv_init
-	${VENV_DIRECTORY}/${EXEC_DIR}/${PYTHON_EXE} -m pytest --cov ${PROJECT_DIRECTORY} --cov-fail-under=${COVERAGE_THRESHOLD} ${TEST_DIRECTORY}/ --suppress-no-test-exit-code
+	${VENV_DIRECTORY}/${EXEC_DIR}/${PYTHON_EXE} -m pytest --cov ${PROJECT_DIRECTORY} --cov-config=${TEST_DIRECTORY}/.coveragerc  --cov-fail-under=${COVERAGE_THRESHOLD} ${TEST_DIRECTORY}/ --suppress-no-test-exit-code 
 
 lint: .installed .venv_init
 	${VENV_DIRECTORY}/${EXEC_DIR}/flake8 ${PROJECT_DIRECTORY}


### PR DESCRIPTION
The purpose of this PR to remove test connectivity file from test coverage because test connectivity file contains test cases of Enterprise Search connection. So this file is not required in test coverage. Hence we are ignoring. 