### PR TITLE
Add connector queue

### DIFF
--- a/ees_microsoft_outlook/connector_queue.py
+++ b/ees_microsoft_outlook/connector_queue.py
@@ -1,0 +1,47 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+import multiprocessing
+from multiprocessing.queues import Queue
+
+
+class ConnectorQueue(Queue):
+    """Class to support additional queue operations specific to the connector"""
+
+    def __init__(self, logger):
+        ctx = multiprocessing.get_context()
+        super(ConnectorQueue, self).__init__(ctx=ctx)
+        self.logger = logger
+
+    def end_signal(self):
+        """Send an terminate signal to indicate the queue can be closed"""
+
+        signal_close = {"type": "signal_close"}
+        self.put(signal_close)
+
+    def put_checkpoint(self, key, checkpoint_time, indexing_type):
+        """Put the checkpoint object in the queue which will be used by the consumer to update the checkpoint file
+        :param key: The key of the checkpoint dictionary
+        :param checkpoint_time: The end time that will be stored in the checkpoint as {'key': 'checkpoint_time'}
+        :param indexing_type: The type of the indexing i.e. Full or Incremental
+        """
+
+        checkpoint = {
+            "type": "checkpoint",
+            "data": (key, checkpoint_time, indexing_type),
+        }
+        self.put(checkpoint)
+
+    def append_to_queue(self, type, documents):
+        """Append documents to the shared queue
+        :param type: Type of documents
+        :param documents: Documents fetched from sharepoint
+        """
+        if documents:
+            documents_map = {"type": type, "data": documents}
+            self.logger.debug(
+                f"Added list of {len(documents)} documents into the queue"
+            )
+            self.put(documents_map)

--- a/tests/test_connector_queue.py
+++ b/tests/test_connector_queue.py
@@ -1,0 +1,74 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+import logging
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ees_microsoft_outlook.connector_queue import ConnectorQueue  # noqa
+from ees_microsoft_outlook.utils import get_current_time  # noqa
+
+
+def create_connector_queue_object():
+    """Create connector queue object"""
+    logger = logging.getLogger("unit_test_connector_queue")
+    return ConnectorQueue(logger)
+
+
+def test_end_signal():
+    """Tests that the end signal is sent to the queue to notify it to stop listening for new incoming data"""
+    # Setup
+    expected_message = {"type": "signal_close"}
+    queue = create_connector_queue_object()
+    queue.put("Example data")
+
+    # Execute
+    queue.end_signal()
+    queue.get()
+    current_message = queue.get()
+
+    # Assert
+    assert current_message == expected_message
+
+
+def test_put_checkpoint():
+    """Tests that the update the checkpoint in queue"""
+    # Setup
+    current_time = get_current_time()
+    expected_message = {"type": "checkpoint", "data": ("key", current_time, "full")}
+    queue = create_connector_queue_object()
+
+    # Execute
+    queue.put("Example data")
+    queue.put_checkpoint("key", current_time, "full")
+    queue.end_signal()
+    queue.get()
+    current_message = queue.get()
+    queue.get()
+
+    # Assert
+    assert current_message == expected_message
+
+
+def test_append_to_queue():
+    """Tests that the append data in queue"""
+    # Setup
+    data = []
+    for count in range(10):
+        data.append(count)
+    expected_message = {"type": "document_list", "data": data}
+    queue = create_connector_queue_object()
+
+    # Execute
+    queue.append_to_queue("document_list", data)
+    queue.end_signal()
+    current_message = queue.get()
+    queue.get()
+
+    # Assert
+    assert current_message == expected_message


### PR DESCRIPTION
In this PR we added below functions into ConnectorQueue class
1. **end_signal**: The purpose of the function is stop the execution of thread while syncing the data into the Workplace Search.
2. **put_checkpoint**: The purpose of the function is to add checkpoint details into queue. So, consumer will read the checkpoint from queue and update into the checkpoint file.
3. **append_to_queue**: The purpose of the function is to add documents into queue. So, consumer will read the data from queue and insert it into Workplace Search.

Also, we have added test cases of it.