### PR TITLE
[CI] [Buildkite] Add Catalog Info and Sample Pipeline for Buildkite Migration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,9 +3,5 @@ agents:
   machineType: "n1-standard-4"
 
 steps:
-  - label: ":wrench: Linting"
-    command: 'docker run -v `pwd`:/ci -w=/ci --rm --name jenkins-linter -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3 make lint'
-  - label: ":safety_vest: Testing"
-    command: 'docker run -v `pwd`:/ci -w=/ci --rm --name jenkins-linter -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3 make test'
-  - label: ":safety_vest: Test Coverage"
-    command: 'docker run -v `pwd`:/ci -w=/ci --rm --name jenkins-linter -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3 make cover'
+  - label: "Sample Pipeline"
+    command: 'echo "hello world!"'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,11 @@
+agents:
+  provider: "gcp"
+  machineType: "n1-standard-4"
+
+steps:
+  - label: ":wrench: Linting"
+    command: 'docker run -v `pwd`:/ci -w=/ci --rm --name jenkins-linter -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3 make lint'
+  - label: ":safety_vest: Testing"
+    command: 'docker run -v `pwd`:/ci -w=/ci --rm --name jenkins-linter -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3 make test'
+  - label: ":safety_vest: Test Coverage"
+    command: 'docker run -v `pwd`:/ci -w=/ci --rm --name jenkins-linter -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3 make cover'

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,53 @@
+###################### catalog-info for enterprise-search-microsoft-outlook-connector
+# Declare a Backstage Component for enterprise-search-microsoft-outlook-connector
+# When doing changes validate them using https://backstage.elastic.dev/entity-validation
+---
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "enterprise-search-microsoft-outlook-connector"
+  description: "Enterprise Search Rails Monolith"
+  annotations:
+    backstage.io/source-location: "url:https://github.com/elastic/enterprise-search-microsoft-outlook-connector/"
+    github.com/project-slug: "elastic/enterprise-search-microsoft-outlook-connector"
+    github.com/team-slug: "elastic/enterprise-search"
+    buildkite.com/project-slug: "elastic/enterprise-search-microsoft-outlook-connector"
+  tags:
+    - "enterprise-search-microsoft-outlook-connector"
+    - "enterprise-search"
+    - "buildkite"
+spec:
+  type: "library"
+  system: "enterprise-search"
+  lifecycle: "production"
+  owner: "group:enterprise-search"
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: search-microsoft-outlook-connector
+  description: Buildkite Pipeline for enterprise-search-microsoft-outlook-connector
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/enterprise-search-microsoft-outlook-connector
+
+spec:
+  type: buildkite-pipeline
+  owner: group:enterprise-search
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: search-microsoft-outlook-connector
+    spec:
+      repository: elastic/enterprise-search-microsoft-outlook-connector
+      pipeline_file: ".buildkite/pipeline.yml"
+      teams:
+        enterprise-search:
+           access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
Adds the catalog information and a sample pipeline for Buildkite migration. The actual Buildkite pipeline will come in a PR after this one.