### PR TITLE
Rename the ingestion-team

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,17 +11,17 @@ metadata:
   annotations:
     backstage.io/source-location: "url:https://github.com/elastic/enterprise-search-microsoft-outlook-connector/"
     github.com/project-slug: "elastic/enterprise-search-microsoft-outlook-connector"
-    github.com/team-slug: "elastic/ingestion-team"
+    github.com/team-slug: "elastic/search-extract-and-transform"
     buildkite.com/project-slug: "elastic/enterprise-search-microsoft-outlook-connector"
   tags:
     - "enterprise-search-microsoft-outlook-connector"
     - "enterprise-search"
-    - "ingestion-team"
+    - "search-extract-and-transform"
     - "buildkite"
 spec:
   type: "library"
   lifecycle: "production"
-  owner: "group:ingestion-team"
+  owner: "group:search-extract-and-transform"
 
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
@@ -36,7 +36,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingestion-team
+  owner: group:search-extract-and-transform
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -47,7 +47,7 @@ spec:
       repository: elastic/enterprise-search-microsoft-outlook-connector
       pipeline_file: ".buildkite/pipeline.yml"
       teams:
-        ingestion-team:
+        search-extract-and-transform:
            access_level: MANAGE_BUILD_AND_READ
         enterprise-search:
            access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
### Description
As part of the GitHub teams renaming initiative, it's required to rename the @elastic/ingestion-team to @elastic/search-extract-and-transform.

This PR is dedicated to renaming @elastic/ingestion-team to @elastic/search-extract-and-transform 